### PR TITLE
Add NonGNU ELPA badge, improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ file:
     (lorem-ipsum-use-default-bindings)
 
 
-This will setup the folling keybindings:
+This will setup the following keybindings:
 
 Key Binding | Function
 ------------|------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lorem Ipsum for Emacs #
 
-Add filler lorem ipsum text to Emacs
+Add filler lorem ipsum text in Emacs.
 
 ## Installation
 
@@ -32,12 +32,12 @@ This will setup the following keybindings:
 
 Key Binding | Function
 ------------|------------------------------
-`C-c l p`   | lorem-ipsum-insert-paragraphs
-`C-c l s`   | lorem-ipsum-insert-sentences
-`C-c l l`   | lorem-ipsum-insert-list
+`C-c l p`   | `lorem-ipsum-insert-paragraphs`
+`C-c l s`   | `lorem-ipsum-insert-sentences`
+`C-c l l`   | `lorem-ipsum-insert-list`
 
-If you want different keybinding, say you want the prefix C-c C-l, use a variation of the
-following:
+If you want different keybinding, say you want the prefix `C-c C-l`,
+use a variation of the following:
 
     (global-set-key (kbd "C-c C-l s") 'lorem-ipsum-insert-sentences)
     (global-set-key (kbd "C-c C-l p") 'lorem-ipsum-insert-paragraphs)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/lorem-ipsum.svg)](https://elpa.nongnu.org/nongnu/lorem-ipsum.html)
+
 # Lorem Ipsum for Emacs #
 
 Add filler lorem ipsum text in Emacs.
 
 ## Installation
 
-**MELPA**
+**NonGNU ELPA or MELPA**
 
-This package is available via MELPA. You can install it by calling:
+This package is available via [NonGNU ELPA](https://elpa.nongnu.org/)
+and MELPA.  You can install it by calling:
 
-    M-x package-install RET lorem-ipsum
+    M-x package-install RET lorem-ipsum RET
 
-Finally, the package must be required:
-
-    (require 'lorem-ipsum)
+That's it, all the functions you need are `autoload`ed.
 
 **Manual Installation**
 
-Add `lorem-ipsum.el` to your `load-path`.  That's it, all the
-functions you need are `autoload`ed.
+Add `lorem-ipsum.el` to your `load-path`.  Finally, the package must
+be required:
 
+    (require 'lorem-ipsum)
 
 ## Setup
 

--- a/lorem-ipsum.el
+++ b/lorem-ipsum.el
@@ -39,7 +39,7 @@
 ;;
 ;; (lorem-ipsum-use-default-bindings)
 ;;
-;; This will setup the folling keybindings:
+;; This will setup the following keybindings:
 ;;
 ;; C-c l p: lorem-ipsum-insert-paragraphs
 ;; C-c l s: lorem-ipsum-insert-sentences


### PR DESCRIPTION
This PR:
- Adds a NonGNU ELPA badge to `README.md`.
- Fixes the installation instructions, and formatting in `README.md`.
- Fixes two typos.